### PR TITLE
support extraEnvVars, extraEnvVarsCM, extraEnvVarsSecret

### DIFF
--- a/trufflehog/templates/_helpers.tpl
+++ b/trufflehog/templates/_helpers.tpl
@@ -81,3 +81,15 @@ Chart version
 {{- define "trufflehog.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Environment variables
+*/}}
+{{- define "trufflehog.envVars" -}}
+{{- if .Values.extraEnvVars }}
+{{- range .Values.extraEnvVars }}
+- name: {{ .name }}
+  value: {{ .value | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -39,6 +39,21 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           terminationMessagePolicy: FallbackToLogsOnError
+          {{- if .Values.extraEnvVars }}
+          env:
+            {{- include "trufflehog.envVars" . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
+          {{- end }}
           command: ["/usr/local/bin/scanner", "scan", "--config=/secret/config.yaml", "--port=8080"]
           args:
             {{- if .Values.cli.debug }}

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -40,6 +40,23 @@ cli:
   trace: false
   json: false
 
+# Extra environment variables to add to the container
+# Array of key-value pairs, e.g.:
+# extraEnvVars:
+#   - name: LOG_LEVEL
+#     value: "debug"
+#   - name: CUSTOM_VAR
+#     value: "custom-value"
+extraEnvVars: []
+
+# Name of a ConfigMap containing additional environment variables
+# The ConfigMap should contain key-value pairs that will be added as environment variables
+extraEnvVarsCM: ""
+
+# Name of a Secret containing additional environment variables
+# The Secret should contain key-value pairs that will be added as environment variables
+extraEnvVarsSecret: ""
+
 
 probe:
   initialDelaySeconds: 3


### PR DESCRIPTION
This PR adds support for an `extraEnvVars` value to set env vars to be used in the rendered deployment and its pods. It also adds `extraEnvVarCM` for getting env vars from a configmap and `extraEnvVarsSecret` for getting them from a secret dynamically.

As it says in the included values.yaml comment, it takes a list of dicts with name and value:

```
extraEnvVars:
  - name: LOG_LEVEL
    value: "debug"
  - name: CUSTOM_VAR
    value: "custom-value"
```

And if you want to specify a configmap or secret, it can be done like this:

```
extraEnvVarsCM: "mymap"
extraEnvVarsSecret: "mysecret"
```

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/trufflesecurity/helm-charts/pull/10 :point_left:
     - https://github.com/trufflesecurity/helm-charts/pull/12
       - https://github.com/trufflesecurity/helm-charts/pull/11
         - https://github.com/trufflesecurity/helm-charts/pull/13

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->