### PR TITLE
Support taint tolerations

### DIFF
--- a/trufflehog/README.md
+++ b/trufflehog/README.md
@@ -360,6 +360,29 @@ priorityClass:
 
 Configure pod priority. Set `create: false` and specify `name` to use an existing priority class.
 
+### Taint Tolerations
+
+```yaml
+tolerations: []
+```
+
+Configure taint tolerations to allow pods to be scheduled on nodes with matching taints. This is useful for scheduling pods on dedicated nodes or nodes with specific taints.
+
+Example:
+
+```yaml
+tolerations:
+  - key: "key"
+    operator: "Equal"
+    value: "value"
+    effect: "NoSchedule"
+  - key: "dedicated"
+    operator: "Exists"
+    effect: "NoSchedule"
+```
+
+For more information on tolerations, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+
 ### Security Context
 
 ```yaml

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       {{- else }}
       # no priority class, leave it up to the system
       {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext.pod | nindent 8 }}
       volumes:

--- a/trufflehog/values.schema.json
+++ b/trufflehog/values.schema.json
@@ -341,6 +341,56 @@
       },
       "required": ["create", "value"]
     },
+    "tolerations": {
+      "type": "array",
+      "description": "Taint tolerations for the pod. Allows pods to be scheduled on nodes with matching taints",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key of the taint to tolerate"
+          },
+          "operator": {
+            "type": "string",
+            "description": "Operator for the toleration",
+            "enum": ["Equal", "Exists"],
+            "default": "Equal"
+          },
+          "value": {
+            "type": "string",
+            "description": "Value of the taint to tolerate. Only used when operator is 'Equal'"
+          },
+          "effect": {
+            "type": "string",
+            "description": "Effect of the taint to tolerate",
+            "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"],
+            "default": "NoSchedule"
+          },
+          "tolerationSeconds": {
+            "type": "integer",
+            "description": "TolerationSeconds is the period of time the pod can remain bound to a node with a matching taint. Only used when effect is 'NoExecute'",
+            "minimum": 0
+          }
+        },
+        "required": ["key", "operator", "effect"],
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "operator": {
+                  "const": "Equal"
+                }
+              }
+            },
+            "then": {
+              "required": ["value"]
+            }
+          }
+        ]
+      },
+      "default": []
+    },
     "securityContext": {
       "type": "object",
       "description": "Security context configuration",

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -147,6 +147,19 @@ priorityClass:
   name: ""                # Existing priority class to use if create is false
   value: 1000             # Priority value, only used if create is true
 
+# Taint tolerations for the pod
+# Allows pods to be scheduled on nodes with matching taints
+# Example:
+# tolerations:
+#   - key: "key"
+#     operator: "Equal"
+#     value: "value"
+#     effect: "NoSchedule"
+#   - key: "dedicated"
+#     operator: "Exists"
+#     effect: "NoSchedule"
+tolerations: []
+
 securityContext:
   # Pod-level security context
   pod:


### PR DESCRIPTION
This PR adds support for taint tolerations from the values.yaml, giving more flexibility on how the resulting deployment's pods are scheduled.

For example, this allows it to run on spot instances in gke:

```
tolerations:
  - key: "cloud.google.com/gke-spot"
    operator: "Equal"
    value: "true"
    effect: "NoSchedule"
```

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/trufflesecurity/helm-charts/pull/13 :point_left:

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->