### PR TITLE
Add support for adding a custom certificate authority

### DIFF
--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           {{- else if .Values.ca.secret }}
           secret:
             secretName: {{ .Values.ca.secret }}
+          {{- else if .Values.ca.persistentVolumeClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.ca.persistentVolumeClaim }}
           {{- end }}
         {{- end }}
       containers:

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
       {{- if .Values.ca.enabled }}
       initContainers:
         - name: update-ca-certificates
+          securityContext:
+            {{- toYaml .Values.securityContext.container | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           command: ["/bin/sh", "-c", "update-ca-certificates"]

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -28,10 +28,35 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext.pod | nindent 8 }}
+      {{- if .Values.ca.enabled }}
+      initContainers:
+        - name: update-ca-certificates
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          command: ["/bin/sh", "-c", "update-ca-certificates"]
+          volumeMounts:
+            - name: custom-certs
+              mountPath: /usr/local/share/ca-certificates
+              readOnly: true
+            - name: ca-certificates
+              mountPath: /etc/ssl/certs
+      {{- end }}
       volumes:
         - name: config-secret-volume
           secret:
             secretName: {{ .Values.config.secretName }}
+        {{- if .Values.ca.enabled }}
+        - name: ca-certificates
+          emptyDir: {}
+        - name: custom-certs
+          {{- if .Values.ca.configMap }}
+          configMap:
+            name: {{ .Values.ca.configMap }}
+          {{- else if .Values.ca.secret }}
+          secret:
+            secretName: {{ .Values.ca.secret }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: trufflehog
           securityContext:
@@ -77,6 +102,14 @@ spec:
           volumeMounts:
             - name: config-secret-volume
               mountPath: /secret/
+            {{- if .Values.ca.enabled }}
+            - name: custom-certs
+              mountPath: /usr/local/share/ca-certificates
+              readOnly: true
+            - name: ca-certificates
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            {{- end }}
           resources:
             requests:
               memory: "{{ .Values.resources.requests.memory }}"

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -58,12 +58,16 @@ extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 
 # Certificate Authority configuration
-# Supports mounting certificates from a ConfigMap, Secret, or PersistentVolumeClaim with files ending in .crt
+# Supports mounting certificates from a ConfigMap, Secret, or
+# PersistentVolumeClaim with keys/files ending in .crt
 ca:
   # Enable custom CA support
   enabled: false
-  # Specify exactly one of [configMap, secret, persistentVolumeClaim] -- they are mutually exclusive here.
-  # Trusted certs should be files or keys that end with `.crt`.
+  # If custom CA is enabled, Specify exactly one of [configMap, secret,
+  # persistentVolumeClaim] -- they are mutually exclusive here. Trusted certs
+  # should be files (for pvc) or keys (for configMap or secret) that end with
+  # `.crt`. It is recommended to use a configMap or secret, because kubernetes
+  # cannot detect changes to PVC contents.
   configMap: ""
   secret: ""
   persistentVolumeClaim: ""

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -58,16 +58,19 @@ extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 
 # Certificate Authority configuration
-# Supports mounting certificates from a ConfigMap or Secret with keys ending in .crt
+# Supports mounting certificates from a ConfigMap, Secret, or PersistentVolumeClaim with files ending in .crt
 ca:
   # Enable custom CA support
   enabled: false
   # Name of ConfigMap containing CA certificates (keys ending in .crt)
-  # Mutually exclusive with secret
+  # Mutually exclusive with secret and persistentVolumeClaim
   configMap: ""
   # Name of Secret containing CA certificates (keys ending in .crt)
-  # Mutually exclusive with configMap
+  # Mutually exclusive with configMap and persistentVolumeClaim
   secret: ""
+  # Name of PersistentVolumeClaim containing CA certificates (files ending in .crt)
+  # Mutually exclusive with configMap and secret
+  persistentVolumeClaim: ""
 
 
 probe:

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -57,6 +57,18 @@ extraEnvVarsCM: ""
 # The Secret should contain key-value pairs that will be added as environment variables
 extraEnvVarsSecret: ""
 
+# Certificate Authority configuration
+# Supports mounting certificates from a ConfigMap or Secret with keys ending in .crt
+ca:
+  # Enable custom CA support
+  enabled: false
+  # Name of ConfigMap containing CA certificates (keys ending in .crt)
+  # Mutually exclusive with secret
+  configMap: ""
+  # Name of Secret containing CA certificates (keys ending in .crt)
+  # Mutually exclusive with configMap
+  secret: ""
+
 
 probe:
   initialDelaySeconds: 3

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -62,16 +62,11 @@ extraEnvVarsSecret: ""
 ca:
   # Enable custom CA support
   enabled: false
-  # Name of ConfigMap containing CA certificates (keys ending in .crt)
-  # Mutually exclusive with secret and persistentVolumeClaim
+  # Specify exactly one of [configMap, secret, persistentVolumeClaim] -- they are mutually exclusive here.
+  # Trusted certs should be files or keys that end with `.crt`.
   configMap: ""
-  # Name of Secret containing CA certificates (keys ending in .crt)
-  # Mutually exclusive with configMap and persistentVolumeClaim
   secret: ""
-  # Name of PersistentVolumeClaim containing CA certificates (files ending in .crt)
-  # Mutually exclusive with configMap and secret
   persistentVolumeClaim: ""
-
 
 probe:
   initialDelaySeconds: 3
@@ -105,8 +100,8 @@ podAnnotations: {}
 
 priorityClass:
   create: true
-  name: ""                # Existing priority class to use if create is false
-  value: 1000             # Priority value, only used if create is true
+  name: "" # Existing priority class to use if create is false
+  value: 1000 # Priority value, only used if create is true
 
 securityContext:
   # Pod-level security context


### PR DESCRIPTION
This change adds support for specifying a custom certificate authority that the scanner pod trusts. Since the main container defaults to a non-root user, we use an init-container and emptydir to generate a suitable ca-certificates.

Resulting pods will mount the specified configmap or secret as a volume and run `update-ca-certificates` inside an initcontainer.

Note that only one of `persistentVolumeClaim`, `configmap` or `secret` can be specified.

First, create a configmap or secret, eg:

```
kubectl create configmap my-certs --from-file=ca.crt
kubectl create secret generic my-certs-from-secret --from-file=ca.crt
```

An example of using a configmap:

```yaml
...
ca:
  enabled: true
  configMap: "my-certs"
...
```

...and using a secret:

```yaml
...
ca:
  enabled: true
  secret: "my-certs-from-secret"
...
```

Generally, the configmap should look something like this:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-certs
  namespace: my-namespace
data:
  ca.crt: |
    -----BEGIN CERTIFICATE-----
    MIIDazCCAlOgAwIBAgIUWIR9YscV2OUZhsIGghV34aYgPhwwDQYJKoZIhvcNAQEL
    ...
    sdQIEeumwJvqvPdja0dN
    -----END CERTIFICATE-----
  other.crt: |
    -----BEGIN CERTIFICATE-----
    MIIDazCCAlOgAwIBAgIUbRbMomCWa1Nm9GUpjHRguQA5C4kwDQYJKoZIhvcNAQEL
    ...
    ubjOSrpX50tAw4hJwVc4
    -----END CERTIFICATE-----
```

Alternatively, you can mount a persistent volume claim, like this:

```yaml
...
ca:
  enabled: true
  persistentVolumeClaim: "my-certs-from-pvc"
...
```

I've verified the functionality by using the helm chart with a self-signed cert, pulling the resulting ca-certificates.crt bundle and running:

```
$ openssl verify -CAfile ca-certificates.crt ca.crt
ca.crt: OK
```