### PR TITLE
move customization values into a `custom` yaml key and add support for custom volumes and mounts

### DIFF
--- a/trufflehog/templates/_helpers.tpl
+++ b/trufflehog/templates/_helpers.tpl
@@ -86,8 +86,8 @@ Chart version
 Environment variables
 */}}
 {{- define "trufflehog.envVars" -}}
-{{- if .Values.extraEnvVars }}
-{{- range .Values.extraEnvVars }}
+{{- if .Values.custom.envVars }}
+{{- range .Values.custom.envVars }}
 - name: {{ .name }}
   value: {{ .value | quote }}
 {{- end }}

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
             claimName: {{ .Values.ca.persistentVolumeClaim }}
           {{- end }}
         {{- end }}
+        {{- if .Values.custom.volumes }}
+        {{- toYaml .Values.custom.volumes | nindent 8 }}
+        {{- end }}
       containers:
         - name: trufflehog
           securityContext:
@@ -69,19 +72,19 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           terminationMessagePolicy: FallbackToLogsOnError
-          {{- if .Values.extraEnvVars }}
+          {{- if .Values.custom.envVars }}
           env:
             {{- include "trufflehog.envVars" . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          {{- if or .Values.custom.envVarsCM .Values.custom.envVarsSecret }}
           envFrom:
-            {{- if .Values.extraEnvVarsCM }}
+            {{- if .Values.custom.envVarsCM }}
             - configMapRef:
-                name: {{ .Values.extraEnvVarsCM }}
+                name: {{ .Values.custom.envVarsCM }}
             {{- end }}
-            {{- if .Values.extraEnvVarsSecret }}
+            {{- if .Values.custom.envVarsSecret }}
             - secretRef:
-                name: {{ .Values.extraEnvVarsSecret }}
+                name: {{ .Values.custom.envVarsSecret }}
             {{- end }}
           {{- end }}
           command: ["/usr/local/bin/scanner", "scan", "--config=/secret/config.yaml", "--port=8080"]
@@ -105,6 +108,9 @@ spec:
             initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             periodSeconds: {{ .Values.probe.periodSeconds }}
           volumeMounts:
+            {{- if .Values.custom.volumeMounts }}
+            {{- toYaml .Values.custom.volumeMounts | nindent 12 }}
+            {{- end }}
             - name: config-secret-volume
               mountPath: /secret/
             {{- if .Values.ca.enabled }}

--- a/trufflehog/values.schema.json
+++ b/trufflehog/values.schema.json
@@ -1,0 +1,555 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "TruffleHog Enterprise Helm Chart Values",
+  "description": "Schema for TruffleHog Enterprise Helm chart values",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "description": "Sets the number of pod replicas",
+      "default": 1,
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository",
+          "default": "us-docker.pkg.dev/thog-artifacts/public/scanner"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag",
+          "default": "latest"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "default": "Always"
+        }
+      },
+      "required": ["repository", "tag"]
+    },
+    "resources": {
+      "type": "object",
+      "description": "The resources requests and limits for the TruffleHog Enterprise container",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "description": "Memory request",
+              "default": "16Gi"
+            },
+            "cpu": {
+              "type": "string",
+              "description": "CPU request",
+              "default": "4000m"
+            },
+            "ephemeralStorage": {
+              "type": "string",
+              "description": "Ephemeral storage request",
+              "default": "10Gi"
+            }
+          },
+          "required": ["memory", "cpu", "ephemeralStorage"]
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable resource limits",
+              "default": true
+            },
+            "memory": {
+              "type": "string",
+              "description": "Memory limit",
+              "default": "48Gi"
+            },
+            "cpu": {
+              "type": "string",
+              "description": "CPU limit",
+              "default": "12000m"
+            },
+            "ephemeralStorage": {
+              "type": "string",
+              "description": "Ephemeral storage limit",
+              "default": "30Gi"
+            }
+          },
+          "required": ["enabled"],
+          "if": {
+            "properties": {
+              "enabled": {"const": true}
+            }
+          },
+          "then": {
+            "anyOf": [
+              {"required": ["cpu"]},
+              {"required": ["memory"]},
+              {"required": ["ephemeralStorage"]}
+            ]
+          }
+        }
+      },
+      "required": ["requests", "limits"]
+    },
+    "vpa": {
+      "type": "object",
+      "description": "A VerticalPodAutoscaler will adjust resource requests based on observed CPU and memory usage",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable VerticalPodAutoscaler",
+          "default": true
+        },
+        "minAllowed": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "description": "Minimum allowed CPU",
+              "default": "4000m"
+            },
+            "memory": {
+              "type": "string",
+              "description": "Minimum allowed memory",
+              "default": "16Gi"
+            }
+          },
+          "required": ["cpu", "memory"]
+        },
+        "maxAllowed": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable maximum allowed resources",
+              "default": true
+            },
+            "memory": {
+              "type": "string",
+              "description": "Maximum allowed memory",
+              "default": "48Gi"
+            },
+            "cpu": {
+              "type": "string",
+              "description": "Maximum allowed CPU",
+              "default": "12000m"
+            }
+          },
+          "required": ["enabled"]
+        }
+      },
+      "required": ["enabled", "minAllowed", "maxAllowed"]
+    },
+    "config": {
+      "type": "object",
+      "description": "Configures the Kubernetes secret that provides the application's configuration data",
+      "properties": {
+        "secretName": {
+          "type": "string",
+          "description": "Name of the secret containing configuration",
+          "default": "config"
+        }
+      },
+      "required": ["secretName"]
+    },
+    "cli": {
+      "type": "object",
+      "description": "Configures the CLI options for the scanner",
+      "properties": {
+        "debug": {
+          "type": "boolean",
+          "description": "Enable debug mode",
+          "default": false
+        },
+        "quiet": {
+          "type": "boolean",
+          "description": "Enable quiet mode",
+          "default": false
+        },
+        "trace": {
+          "type": "boolean",
+          "description": "Enable trace mode",
+          "default": false
+        },
+        "json": {
+          "type": "boolean",
+          "description": "Enable JSON output",
+          "default": false
+        }
+      },
+      "required": ["debug", "quiet", "trace", "json"]
+    },
+    "custom": {
+      "type": "object",
+      "description": "Custom configurations for volumes, volume mounts, and environment variables",
+      "properties": {
+        "envVars": {
+          "type": "array",
+          "description": "Extra environment variables to add to the container",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "valueFrom": {
+                "type": "object",
+                "oneOf": [
+                  {
+                    "properties": {
+                      "configMapKeyRef": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["name", "key"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": ["configMapKeyRef"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "properties": {
+                      "secretKeyRef": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["name", "key"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": ["secretKeyRef"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "required": ["name"],
+            "oneOf": [
+              {
+                "required": ["value"],
+                "not": {
+                  "required": ["valueFrom"]
+                }
+              },
+              {
+                "required": ["valueFrom"],
+                "not": {
+                  "required": ["value"]
+                }
+              }
+            ],
+            "additionalProperties": false
+          },
+          "default": []
+        },
+        "envVarsCM": {
+          "type": "string",
+          "description": "Name of a ConfigMap containing additional environment variables",
+          "default": ""
+        },
+        "envVarsSecret": {
+          "type": "string",
+          "description": "Name of a Secret containing additional environment variables",
+          "default": ""
+        },
+        "volumes": {
+          "type": "array",
+          "description": "Extra volumes to add to the pod. NOTE: the volume names [config-secret-volume, ca-certificates, custom-certs] are reserved for internal chart use",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "volumeMounts": {
+          "type": "array",
+          "description": "Extra volume mounts to add to the container. NOTE: These mounts will appear before trufflehog config and CA configuration mounts in the final deployment.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "mountPath": {
+                "type": "string"
+              },
+              "readOnly": {
+                "type": "boolean"
+              }
+            },
+            "required": ["name", "mountPath"]
+          },
+          "default": []
+        }
+      }
+    },
+    "ca": {
+      "type": "object",
+      "description": "Certificate Authority configuration. Supports mounting certificates from a ConfigMap, Secret, or PersistentVolumeClaim with keys/files ending in .crt",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable custom CA support",
+          "default": false
+        },
+        "configMap": {
+          "type": "string",
+          "description": "Name of ConfigMap containing CA certificates (mutually exclusive with secret and persistentVolumeClaim)",
+          "default": ""
+        },
+        "secret": {
+          "type": "string",
+          "description": "Name of Secret containing CA certificates (mutually exclusive with configMap and persistentVolumeClaim)",
+          "default": ""
+        },
+        "persistentVolumeClaim": {
+          "type": "string",
+          "description": "Name of PersistentVolumeClaim containing CA certificates (mutually exclusive with configMap and secret)",
+          "default": ""
+        }
+      },
+      "required": ["enabled"],
+      "if": {
+        "properties": {
+          "enabled": {"const": true}
+        }
+      },
+      "then": {
+        "oneOf": [
+          {
+            "required": ["configMap"],
+            "properties": {
+              "configMap": {"type": "string", "minLength": 1}
+            },
+            "not": {
+              "anyOf": [
+                {"properties": {"secret": {"type": "string", "minLength": 1}}},
+                {"properties": {"persistentVolumeClaim": {"type": "string", "minLength": 1}}}
+              ]
+            }
+          },
+          {
+            "required": ["secret"],
+            "properties": {
+              "secret": {"type": "string", "minLength": 1}
+            },
+            "not": {
+              "anyOf": [
+                {"properties": {"configMap": {"type": "string", "minLength": 1}}},
+                {"properties": {"persistentVolumeClaim": {"type": "string", "minLength": 1}}}
+              ]
+            }
+          },
+          {
+            "required": ["persistentVolumeClaim"],
+            "properties": {
+              "persistentVolumeClaim": {"type": "string", "minLength": 1}
+            },
+            "not": {
+              "anyOf": [
+                {"properties": {"configMap": {"type": "string", "minLength": 1}}},
+                {"properties": {"secret": {"type": "string", "minLength": 1}}}
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "probe": {
+      "type": "object",
+      "description": "Liveness probe configuration",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Initial delay before the first probe",
+          "default": 3,
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Period between probe executions",
+          "default": 3,
+          "minimum": 1
+        }
+      },
+      "required": ["initialDelaySeconds", "periodSeconds"]
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the chart",
+      "default": ""
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Common labels to add to all resources",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "description": "Common annotations to add to all resources",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels to add to pods",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Additional annotations to add to pods",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "priorityClass": {
+      "type": "object",
+      "description": "Priority class configuration",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create a priority class",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Existing priority class to use if create is false",
+          "default": ""
+        },
+        "value": {
+          "type": "integer",
+          "description": "Priority value, only used if create is true",
+          "default": 1000
+        }
+      },
+      "required": ["create"],
+      "if": {
+        "properties": {
+          "create": {
+            "const": false
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["name"]
+      },
+      "else": {
+        "properties": {
+          "value": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context configuration",
+      "properties": {
+        "pod": {
+          "type": "object",
+          "description": "Pod-level security context",
+          "properties": {
+            "runAsNonRoot": {
+              "type": "boolean",
+              "default": true
+            },
+            "runAsUser": {
+              "type": "integer",
+              "default": 1000
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "default": 1000
+            },
+            "fsGroup": {
+              "type": "integer",
+              "default": 1000
+            }
+          },
+          "required": ["runAsNonRoot", "runAsUser", "runAsGroup", "fsGroup"]
+        },
+        "container": {
+          "type": "object",
+          "description": "Container-level security context",
+          "properties": {
+            "runAsNonRoot": {
+              "type": "boolean",
+              "default": true
+            },
+            "runAsUser": {
+              "type": "integer",
+              "default": 1000
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "default": false
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "add": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "required": ["runAsNonRoot", "runAsUser", "allowPrivilegeEscalation", "capabilities"]
+        }
+      },
+      "required": ["pod", "container"]
+    }
+  }
+}
+

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -45,10 +45,14 @@ custom:
   # Extra environment variables to add to the container
   # Array of key-value pairs, e.g.:
   # envVars:
-  #   - name: LOG_LEVEL
-  #     value: "debug"
   #   - name: CUSTOM_VAR
-  #     value: "custom-value"
+  #     value: "custom_value"
+  #   - name: ANOTHER_VAR
+  #     valueFrom:
+  #     configMapKeyRef:
+  #       name: my-special-configmap
+  #       key: some-configmap-key
+
   envVars: []
   # Name of a ConfigMap containing additional environment variables
   # The ConfigMap should contain key-value pairs that will be added as environment variables

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -62,19 +62,20 @@ custom:
   #   - name: my-data-pvc
   #     persistentVolumeClaim:
   #       claimName: existing-data-pvc
-  #   - name: my-config
+  #   - name: my-configmap
   #     configMap:
   #       name: my-configmap
+  # NOTE: the volume names [config-secret-volume, ca-certificates, custom-certs] are reserved for internal chart use
   volumes: []
   # Extra volume mounts to add to the container
   # Array of volume mount definitions, e.g.:
   # volumeMounts:
   #   - name: my-data-pvc
   #     mountPath: /data
-  #   - name: my-config
-  #     mountPath: /config
+  #   - name: my-configmap
+  #     mountPath: /my-configmap
   #     readOnly: true
-  # Note: These mounts will appear before CA configuration mounts in the final deployment.
+  # NOTE: These mounts will appear before trufflehog config and CA configuration mounts in the final deployment.
   volumeMounts: []
 
 # Certificate Authority configuration

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -40,22 +40,42 @@ cli:
   trace: false
   json: false
 
-# Extra environment variables to add to the container
-# Array of key-value pairs, e.g.:
-# extraEnvVars:
-#   - name: LOG_LEVEL
-#     value: "debug"
-#   - name: CUSTOM_VAR
-#     value: "custom-value"
-extraEnvVars: []
-
-# Name of a ConfigMap containing additional environment variables
-# The ConfigMap should contain key-value pairs that will be added as environment variables
-extraEnvVarsCM: ""
-
-# Name of a Secret containing additional environment variables
-# The Secret should contain key-value pairs that will be added as environment variables
-extraEnvVarsSecret: ""
+# Custom configurations for volumes, volume mounts, and environment variables
+custom:
+  # Extra environment variables to add to the container
+  # Array of key-value pairs, e.g.:
+  # envVars:
+  #   - name: LOG_LEVEL
+  #     value: "debug"
+  #   - name: CUSTOM_VAR
+  #     value: "custom-value"
+  envVars: []
+  # Name of a ConfigMap containing additional environment variables
+  # The ConfigMap should contain key-value pairs that will be added as environment variables
+  envVarsCM: ""
+  # Name of a Secret containing additional environment variables
+  # The Secret should contain key-value pairs that will be added as environment variables
+  envVarsSecret: ""
+  # Extra volumes to add to the pod
+  # Array of volume definitions, e.g.:
+  # volumes:
+  #   - name: my-data-pvc
+  #     persistentVolumeClaim:
+  #       claimName: existing-data-pvc
+  #   - name: my-config
+  #     configMap:
+  #       name: my-configmap
+  volumes: []
+  # Extra volume mounts to add to the container
+  # Array of volume mount definitions, e.g.:
+  # volumeMounts:
+  #   - name: my-data-pvc
+  #     mountPath: /data
+  #   - name: my-config
+  #     mountPath: /config
+  #     readOnly: true
+  # Note: These mounts will appear before CA configuration mounts in the final deployment.
+  volumeMounts: []
 
 # Certificate Authority configuration
 # Supports mounting certificates from a ConfigMap, Secret, or

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -1,4 +1,4 @@
-# Sets the number of pod replicas.
+## Sets the number of pod replicas.
 replicaCount: 1
 
 image:
@@ -6,7 +6,7 @@ image:
   tag: latest
   pullPolicy: Always
 
-# The resources requests and limits for the TruffleHog Enterprise container.
+## The resources requests and limits for the TruffleHog Enterprise container.
 resources:
   requests:
     memory: "16Gi"
@@ -18,7 +18,7 @@ resources:
     cpu: "12000m"
     ephemeralStorage: "30Gi"
 
-# A VerticalPodAutoscaler will adjust resource requests based on observed CPU and memory usage.
+## A VerticalPodAutoscaler will adjust resource requests based on observed CPU and memory usage.
 vpa:
   enabled: true
   minAllowed:
@@ -29,70 +29,73 @@ vpa:
     memory: "48Gi"
     cpu: "12000m"
 
-# Configures the Kubernetes secret that provides the application's configuration data.
+## Configures the Kubernetes secret that provides the application's configuration data.
 config:
   secretName: config
 
-# Configures the CLI options for the scanner.
+## Configures the CLI options for the scanner.
 cli:
   debug: false
   quiet: false
   trace: false
   json: false
 
-# Custom configurations for volumes, volume mounts, and environment variables
+## Custom configurations for volumes, volume mounts, and environment variables
 custom:
-  # Extra environment variables to add to the container
-  # Array of key-value pairs, e.g.:
-  # envVars:
-  #   - name: CUSTOM_VAR
-  #     value: "custom_value"
-  #   - name: ANOTHER_VAR
-  #     valueFrom:
-  #     configMapKeyRef:
-  #       name: my-special-configmap
-  #       key: some-configmap-key
-
+  ## Extra environment variables to add to the container
+  ## Array of key-value pairs, e.g.:
+  ## envVars:
+  ##   - name: CUSTOM_VAR
+  ##     value: "custom_value"
+  ##   - name: ANOTHER_VAR
+  ##     valueFrom:
+  ##     configMapKeyRef:
+  ##       name: my-special-configmap
+  ##       key: some-configmap-key
   envVars: []
-  # Name of a ConfigMap containing additional environment variables
-  # The ConfigMap should contain key-value pairs that will be added as environment variables
+
+  ## Name of a ConfigMap containing additional environment variables
+  ## The ConfigMap should contain key-value pairs that will be added as environment variables
   envVarsCM: ""
-  # Name of a Secret containing additional environment variables
-  # The Secret should contain key-value pairs that will be added as environment variables
+
+  ## Name of a Secret containing additional environment variables
+  ## The Secret should contain key-value pairs that will be added as environment variables
   envVarsSecret: ""
-  # Extra volumes to add to the pod
-  # Array of volume definitions, e.g.:
-  # volumes:
-  #   - name: my-data-pvc
-  #     persistentVolumeClaim:
-  #       claimName: existing-data-pvc
-  #   - name: my-configmap
-  #     configMap:
-  #       name: my-configmap
-  # NOTE: the volume names [config-secret-volume, ca-certificates, custom-certs] are reserved for internal chart use
+
+  ## Extra volumes to add to the pod
+  ## Array of volume definitions, e.g.:
+  ## volumes:
+  ##   - name: my-data-pvc
+  ##     persistentVolumeClaim:
+  ##       claimName: existing-data-pvc
+  ##   - name: my-configmap
+  ##     configMap:
+  ##       name: my-configmap
+  ## The volume names [config-secret-volume, ca-certificates, custom-certs] are reserved for internal chart use
   volumes: []
-  # Extra volume mounts to add to the container
-  # Array of volume mount definitions, e.g.:
-  # volumeMounts:
-  #   - name: my-data-pvc
-  #     mountPath: /data
-  #   - name: my-configmap
-  #     mountPath: /my-configmap
-  #     readOnly: true
-  # NOTE: These mounts will appear before trufflehog config and CA configuration mounts in the final deployment.
+
+  ## Extra volume mounts to add to the container
+  ## Array of volume mount definitions, e.g.:
+  ## volumeMounts:
+  ##   - name: my-data-pvc
+  ##     mountPath: /data
+  ##   - name: my-configmap
+  ##     mountPath: /my-configmap
+  ##     readOnly: true
+  ## These mounts will appear before trufflehog config and CA configuration mounts in the final deployment.
   volumeMounts: []
 
-# Certificate Authority configuration
-# Supports mounting certificates from a ConfigMap, Secret, or
-# PersistentVolumeClaim with keys/files ending in .crt
+## Certificate Authority configuration
+## Supports mounting certificates from a ConfigMap, Secret, or
+## PersistentVolumeClaim with keys/files ending in .crt
 ca:
-  # Enable custom CA support
+  ## Enable custom CA support
   enabled: false
-  # If custom CA is enabled, Specify exactly one of [configMap, secret,
-  # persistentVolumeClaim] -- they are mutually exclusive here. Trusted certs
-  # should be files (for pvc) or keys (for configMap or secret) that end with
-  # `.crt`. It is recommended to use a configMap or secret, because kubernetes
-  # cannot detect changes to PVC contents.
+  ## If custom CA is enabled, Specify exactly one of [configMap, secret,
+  ## persistentVolumeClaim] -- they are mutually exclusive here. Trusted certs
+  ## should be files (for pvc) or keys (for configMap or secret) that end with
+  ## `.crt`. It is recommended to use a configMap or secret, because kubernetes
+  ## cannot detect changes to PVC contents.
   configMap: ""
   secret: ""
   persistentVolumeClaim: ""
@@ -104,22 +107,22 @@ probe:
 nameOverride: ""
 fullnameOverride: ""
 
-# Common labels to add to all resources
+## Common labels to add to all resources
 commonLabels: {}
   # environment: production
   # team: security
 
-# Common annotations to add to all resources
+## Common annotations to add to all resources
 commonAnnotations: {}
   # prometheus.io/scrape: "true"
   # prometheus.io/port: "8080"
 
-# Additional labels to add to pods
+## Additional labels to add to pods
 podLabels: {}
   # security-scan: enabled
   # pod-type: scanner
 
-# Additional annotations to add to pods
+## Additional annotations to add to pods
 podAnnotations: {}
   # prometheus.io/scrape: "true"
   # prometheus.io/port: "8080"
@@ -129,17 +132,17 @@ podAnnotations: {}
 
 priorityClass:
   create: true
-  name: "" # Existing priority class to use if create is false
-  value: 1000 # Priority value, only used if create is true
+  name: "" ## Existing priority class to use if create is false
+  value: 1000 ## Priority value, only used if create is true
 
 securityContext:
-  # Pod-level security context
+  ## Pod-level security context
   pod:
     runAsNonRoot: true
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
-  # Container-level security context
+  ## Container-level security context
   container:
     runAsNonRoot: true
     runAsUser: 1000


### PR DESCRIPTION
This PR adds support for custom volumes and volume mounts from things like PVCs, configmaps, secrets, etc.

It also updates the schema of the values.yaml to namespace user customizations: they are now nested under a `custom` key.

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/trufflesecurity/helm-charts/pull/17 :point_left:

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->