### PR TITLE
Add update strategy

### DIFF
--- a/trufflehog/Chart.yaml
+++ b/trufflehog/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: trufflehog
 description: A Helm chart for TruffleHog Enterprise
-version: 0.3.0
+version: 0.4.0

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -9,6 +9,14 @@ metadata:
     {{- include "trufflehog.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    type: {{ .type }}
+    {{- if and (eq .type "RollingUpdate") .rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .rollingUpdate | nindent 6 }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "trufflehog.selectorLabels" . | nindent 6 }}

--- a/trufflehog/values.schema.json
+++ b/trufflehog/values.schema.json
@@ -10,6 +10,35 @@
       "default": 1,
       "minimum": 1
     },
+    "strategy": {
+      "type": "object",
+      "description": "Deployment update strategy configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Deployment strategy type",
+          "enum": ["RollingUpdate", "Recreate"],
+          "default": "RollingUpdate"
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "description": "Rolling update configuration, only used when type is RollingUpdate",
+          "properties": {
+            "maxSurge": {
+              "type": ["string", "integer"],
+              "description": "Maximum number of pods that can be created over the desired number of pods (absolute number or percentage)",
+              "default": "25%"
+            },
+            "maxUnavailable": {
+              "type": ["string", "integer"],
+              "description": "Maximum number of pods that can be unavailable during the update (absolute number or percentage)",
+              "default": "25%"
+            }
+          }
+        }
+      },
+      "required": ["type"]
+    },
     "image": {
       "type": "object",
       "description": "Container image configuration",

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -1,6 +1,15 @@
 ## Sets the number of pod replicas.
 replicaCount: 1
 
+## Deployment update strategy configuration.
+## type: RollingUpdate or Recreate
+## rollingUpdate: only used when type is RollingUpdate
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: "25%"
+    maxUnavailable: "25%"
+
 image:
   repository: us-docker.pkg.dev/thog-artifacts/public/scanner
   tag: latest

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -1,9 +1,9 @@
 ## Sets the number of pod replicas.
 replicaCount: 1
 
-## Deployment update strategy configuration.
-## type: RollingUpdate or Recreate
-## rollingUpdate: only used when type is RollingUpdate
+## Controls how pods are replaced during upgrades.
+## RollingUpdate: gradually replaces pods, keeping the service available.
+## Recreate: terminates all existing pods before creating new ones (causes downtime).
 strategy:
   type: RollingUpdate
   rollingUpdate:


### PR DESCRIPTION
Adding updateStrategy as a helm chart value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm chart change that only affects how Kubernetes rolls out updates when users opt into a non-default strategy (e.g., `Recreate` can cause downtime). Defaults preserve current behavior.
> 
> **Overview**
> Adds a new `strategy` values block to control the Kubernetes Deployment update behavior (type plus optional `rollingUpdate.maxSurge`/`maxUnavailable`), wiring it into `templates/deployment.yaml` and validating it via `values.schema.json`.
> 
> Bumps the chart version to `0.4.0` and documents default `RollingUpdate` settings in `values.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 791d95ab801e2de13c07ff7f6bec919eac4555d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->