### PR TITLE
Phase 2: add sync-labels caller workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,13 @@
+name: Sync Labels
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    uses: trufflesecurity/.github-private/.github/workflows/label-sync-reusable.yml@main


### PR DESCRIPTION
## Summary

Phase 2 of the [PR Labeling & Hygiene plan](https://www.notion.so/PR-Labeling-Hygiene-1f0b6e8d-pr_labeling_and_hygiene_5b9ac6e6). Adds a thin caller workflow that invokes the org-internal reusable label-sync workflow in `trufflesecurity/.github-private`. Runs daily at midnight UTC and on demand via `workflow_dispatch`.

The reusable workflow is **additive and idempotent** — it reads `labels.yml` and runs `gh label create --force` for each entry. Labels in this repo not in `labels.yml` are left alone, so legacy labels remain undisturbed.

## What this enables

After this lands and a one-time manual `workflow_dispatch` run, this repo will have the org's standard 11-label taxonomy:

- `size/XS`, `size/S`, `size/M`, `size/L`, `size/XL`
- `risk/low`, `risk/medium`, `risk/high`
- `review/urgent`, `status/stale`, `complexity/high`

Phase 2's labeler PR (next) depends on these labels existing.

## Permissions

Caller grants `issues: write` (labels are an issue resource in GitHub's permission model). Inherited by the reusable workflow via `GITHUB_TOKEN`.

## Test plan

- [x] CI runs green on this PR (no jobs are triggered until merge to `main` + `workflow_dispatch`)
- [ ] After merge: trigger via `gh workflow run sync-labels.yml --repo trufflesecurity/<this-repo>` and verify the 11 labels appear under `Issues > Labels`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adds a GitHub Actions workflow; the main impact is granting `issues: write` and running label-sync automation on a schedule.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `sync-labels.yml`, that runs daily (midnight UTC) and on manual dispatch to sync repository labels.
> 
> The workflow delegates to the org reusable workflow `trufflesecurity/.github-private/.../label-sync-reusable.yml` and grants it `issues: write` permissions to manage labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4669bdc906df05393ff087787f75c1559ab0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->