### PR TITLE
Switch sync-labels caller to public .github reusable

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   sync:
-    uses: trufflesecurity/.github-private/.github/workflows/label-sync-reusable.yml@main
+    uses: trufflesecurity/.github/.github/workflows/label-sync-reusable.yml@main


### PR DESCRIPTION
## Summary
- Switches the `sync-labels.yml` caller workflow's `uses:` reference from `trufflesecurity/.github-private` to `trufflesecurity/.github`.
- Functionally identical: the reusable in the public `.github` repo is a verbatim copy. The reusable already checks out scripts and `labels.yml` from public `.github`, so behavior is unchanged.

## Why
GitHub forbids public repos from consuming reusable workflows that live in private/internal repos, regardless of org-level Actions Access settings. `trufflesecurity/helm-charts` is the only public repo in the PR Labeling rollout, and it could not call the reusables in `.github-private`. Moving the reusables to public `.github` (already merged: trufflesecurity/.github#4) unblocks helm-charts. This PR switches each consumer to the public source so that `.github-private` can be cleaned up afterward.

## Test plan
- [x] CI passes
- [ ] After merge, `gh workflow run sync-labels.yml --repo trufflesecurity/<this-repo>` runs successfully and re-applies the 11 standard labels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow reference change; no application code or data handling is modified.
> 
> **Overview**
> Updates the `Sync Labels` GitHub Actions workflow to call the reusable label sync workflow from `trufflesecurity/.github` instead of `trufflesecurity/.github-private`. This unblocks running the same label synchronization workflow from public repositories without changing behavior of the job itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7d3bf1ee72fb010a3a65a63377d36fc0e1c274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->