### PR TITLE
Add PR labeler caller workflow (Phase 3)

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,31 @@
+name: PR Labels
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number, "all" for full backfill, or empty for no-op'
+        default: ''
+      dry_run:
+        description: 'Log labels without applying'
+        type: boolean
+        default: false
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    uses: trufflesecurity/.github/.github/workflows/pr-labeler-reusable.yml@main
+    with:
+      pr_number: ${{ inputs.pr_number || '' }}
+      # workflow_dispatch boolean inputs can arrive as strings (actions/runner#3571).
+      # Compare both shapes so 'false' is treated as the boolean false, not as a
+      # truthy string by the `|| false` short-circuit pattern.
+      dry_run: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-labeler.yml` -- a thin caller workflow that invokes the org-shared reusable in `trufflesecurity/.github`.
- The reusable applies up to three label families on every PR: size (XS/S/M/L/XL based on lines changed), risk (low/medium/high parsed from the Cursor Bugbot summary in the PR body), and checkbox-driven (`review/urgent`, `complexity/high` from the PR template).
- Triggers: `pull_request` open/synchronize/reopen/edit, plus `workflow_dispatch` for ad-hoc backfills.

## Why
Part of the org-wide [PR Labeling and Hygiene](https://github.com/trufflesecurity/.github-private) rollout. This unblocks reviewers filtering by size, risk, urgency, and complexity to pick up PRs that match their available time and expertise. Sync-labels has already populated this repo with the 11 standard labels, so the labeler will not encounter a label-not-found error on its first run.

## Test plan
- [x] CI passes
- [x] After merge, open or push to a PR -- verify `size/*` and (if Bugbot has run) `risk/*` labels appear within ~30s
- [ ] Backfill dry-run: `gh workflow run pr-labeler.yml --repo trufflesecurity/<this-repo> -f pr_number=all -f dry_run=true` -- check the run logs for the proposed label changes before the real backfill

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone CI workflow that applies PR labels; it doesn’t change application/runtime code, with the main risk being unintended label application due to workflow configuration.
> 
> **Overview**
> Adds a new GitHub Actions workflow `pr-labeler.yml` that runs on PR open/sync/reopen/edit (and via `workflow_dispatch`) to invoke the org-shared `pr-labeler-reusable.yml` with `pull-requests: write` permissions.
> 
> The workflow supports optional manual backfills via `pr_number` and a `dry_run` flag, including explicit handling for `workflow_dispatch` boolean inputs arriving as strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef78e5ee0063b5c7948ced915406b2010929eb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->