### PR TITLE
Add stale PRs caller workflow (Phase 4)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    uses: trufflesecurity/.github/.github/workflows/stale-reusable.yml@main


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/stale.yml` -- a thin caller workflow that invokes the org-shared stale reusable in `trufflesecurity/.github`.
- Wraps `actions/stale@v9` with the org's PR hygiene policy: 14 days to stale, 16 days from stale to close, exempts `review/urgent` and drafts, posts a friendly message on stale and on close, and never deletes branches.
- Triggered nightly at 01:00 UTC (offset from sync-labels at 00:00 UTC to avoid burst-loading the runner queue) plus `workflow_dispatch` for ad-hoc runs.

## Why
Last step of the [PR Labeling and Hygiene](https://github.com/trufflesecurity/.github-private) rollout. With size/risk/checkbox labels now in place across all 7 repos, this enables automatic PR hygiene so stale work doesn't accumulate.

## Behavior
- Only acts on **PRs**, never issues (`days-before-issue-stale: -1` in the reusable).
- Only acts on **non-draft, non-`review/urgent`** PRs.
- A stale PR can be un-staled at any time by pushing a commit, leaving a comment, or editing the PR body (e.g. checking the "Urgent" box in the PR template).
- Throttled to 30 PRs per run (any wave of newly-stale PRs spreads over multiple days).

## Grace window
Today's Phase 3 backfill updated every open PR's `updated_at`, so the **first** auto-stale comments won't appear for at least 14 days regardless of when this merges -- enough time for the Slack announcement to land.

## Test plan
- [x] CI passes (actionlint).
- [ ] After merge, dispatch manually with `gh workflow run stale.yml --repo trufflesecurity/<this-repo>` -- run should complete (no PRs eligible yet given the backfill timestamps).
- [ ] First scheduled run logs visible in Actions tab the morning after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone GitHub Actions workflow and permissions, with no application/runtime code changes; main risk is unintended PR automation behavior if the shared reusable’s policy is misconfigured.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/stale.yml`) that runs nightly at `01:00 UTC` (and via `workflow_dispatch`) and delegates to the org-shared `stale-reusable.yml` workflow to manage stale pull requests.
> 
> The workflow grants `issues: write` and `pull-requests: write` permissions so the reusable job can label/comment/close PRs as needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b11b474431e2e7d66ca428d01f78b47ba7aedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->