### PR TITLE
Added support for overridding the Liveness Probe Timeout

### DIFF
--- a/trufflehog/Chart.yaml
+++ b/trufflehog/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: trufflehog
 description: A Helm chart for TruffleHog Enterprise
-version: 0.4.0
+version: 0.5.0

--- a/trufflehog/templates/deployment.yaml
+++ b/trufflehog/templates/deployment.yaml
@@ -107,6 +107,7 @@ spec:
               port: 8080
             initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             periodSeconds: {{ .Values.probe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probe.timeoutSeconds }}
           volumeMounts:
             {{- if .Values.custom.volumeMounts }}
             {{- toYaml .Values.custom.volumeMounts | nindent 12 }}

--- a/trufflehog/values.schema.json
+++ b/trufflehog/values.schema.json
@@ -393,9 +393,15 @@
           "description": "Period between probe executions",
           "default": 3,
           "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for each probe attempt",
+          "default": 1,
+          "minimum": 1
         }
       },
-      "required": ["initialDelaySeconds", "periodSeconds"]
+      "required": ["initialDelaySeconds", "periodSeconds", "timeoutSeconds"]
     },
     "nameOverride": {
       "type": "string",

--- a/trufflehog/values.yaml
+++ b/trufflehog/values.yaml
@@ -103,6 +103,7 @@ ca:
 probe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  timeoutSeconds: 1
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
A customer asked for us to add support for them to override the LivenessProbeTimeout with a customized value. This PR does that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm chart change that only exposes Kubernetes `livenessProbe.timeoutSeconds` as a configurable value; misconfiguration could cause premature restarts or delayed failure detection.
> 
> **Overview**
> Adds configurable `probe.timeoutSeconds` to the Helm values and schema, and wires it into the Deployment’s `livenessProbe.timeoutSeconds`.
> 
> Bumps the chart version from `0.4.0` to `0.5.0` and sets a default `timeoutSeconds: 1` while making it a required probe value in `values.schema.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf99df75286dd1612e040e5890d41b29a451df1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->