### PR TITLE
ci: bump actions/checkout to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` from `@v4` to `@v6` in `release-helm.yaml`, the only Node-20-era action ref in this repo. Part of the org-wide Node 24 baseline cleanup ahead of GitHub's **2026-09-16 Node 20 removal** deadline (and the earlier **2026-06-02** runner-default flip).

## Action bumps

| action | from | to |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |

## Per-PR preflight

- [x] Rolling `@v6` tag verified (`actions/checkout` SHA `de0fac2e...`, 2026-04-29).
- [x] No conflicting Dependabot/Renovate PRs (none open in this repo).
- [x] No surprise reusable-workflow dependencies in `.github/workflows/`.
- [x] `helm/chart-releaser-action` already SHA-pinned (untouched).

## Risk

**Low.** Pure Node-runtime bump. Defaults (`fetch-depth: 0`) unchanged across v4 → v5 → v6.

## Validation

PR-time CI exercises the workflow indirectly via path filters; the workflow itself runs on `release` events, so post-merge validation is the next chart release. To confirm Node 24 in play after the next natural trigger:

\`\`\`
gh run view <run-id> --repo trufflesecurity/helm-charts --log 2>/dev/null | \\
  grep -E \"Node\\.js (16|20) actions are deprecated\"
\`\`\`

Empty output = green (per [Lesson #2 of the org-wide plan](https://github.com/trufflesecurity)).

## References

- Org-wide plan: \`.cursor/plans/org-wide_node_24_follow-up_a33207ac.plan.md\`
- Approval doc: \`projects/node24-baseline-approval-plan.md\`
- Predecessor PRs (already merged 2026-04-29): trufflesecurity/.github#6, trufflesecurity/.github-private#9

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency bump in a release workflow with no logic changes beyond the action version update.
> 
> **Overview**
> Updates the Helm chart release GitHub Actions workflow to use `actions/checkout@v6` instead of `@v4`, keeping the checkout behavior (including `fetch-depth: 0`) the same while moving to the newer Node runtime baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98b0bf3aa07ff918c78dcef1801d60a8411db7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->