### PR TITLE
Add CODEOWNERS: infra team owns helm-charts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @trufflesecurity/infra


### PR DESCRIPTION
## Summary
- Adds CODEOWNERS file assigning `@trufflesecurity/infra` (DevOps + CTO) as the default owner for all files
- Part of the cross-repo ownership redesign

## Notes
- helm-charts had no CODEOWNERS previously
- Branch protection does not currently enforce CODEOWNER review, so this is advisory until that setting is enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style repo metadata only; no runtime or application code changes.
> 
> **Overview**
> Adds a root **CODEOWNERS** file so every path (`*`) is assigned to **`@trufflesecurity/infra`**, aligning this repo with the cross-repo ownership redesign (helm-charts previously had no owners file).
> 
> Review requests for changes will route to that team by default; enforcement still depends on enabling required CODEOWNER approval in branch protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b192975073debb2d0f6103f3beb479e069759306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->