### PR TITLE
Pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions uses: refs to immutable SHA digests with version comments
- Prevents tag-hijack supply chain attacks
- Version comments allow Renovate to track upstream versions for future updates

## Context

Part of the [Dependency Strategy Unification](https://www.notion.so/35627bbd72b281068f8dd8025da4d3c8) plan (Step 2).

## Test plan

- [x] CI passes (workflows resolve to the same commits as the tags they replaced)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that pins the same action release as before; no application runtime or secrets logic changes.
> 
> **Overview**
> **Pins third-party GitHub Actions to immutable commit SHAs** instead of floating version tags, starting in the Helm release workflow where `actions/checkout` moves from `@v6` to a fixed digest with a `# v6` comment.
> 
> That pattern locks CI to known action code (mitigating tag-move supply-chain risk) while keeping version comments so dependency bots can still propose upgrades. The `chart-releaser-action` step in the same workflow already references a SHA with a version comment; this diff only updates checkout in the snippet shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f357e907e816a76f55b62dd1b037bd5ebe2bc4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->