### PR TITLE
Add shared Renovate config (high-risk tier)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.1"]
+}


### PR DESCRIPTION
## Summary

- Adds/replaces `.github/renovate.json` with the org-wide shared Renovate preset (pinned to `v1.0.1`)
- High-risk tier: **no broad automerge**. Only security/CVE fixes and lockfile maintenance automerge (inherited from shared preset).
- All regular dependency updates (Go, Node, Docker, Python, GitHub Actions) require human review
- Updates are batched to Monday mornings (UTC) with a 3-day minimum release age

## What this does NOT do

- Does NOT automerge minor/patch updates (unlike low-risk repos)
- Does NOT automerge GitHub Actions major version bumps
- Automerge for security/CVE and lockfile maintenance is configured but **will not activate until the Renovate bypass is enabled on GitHub rulesets** (a later step)

## Context

Part of the [Dependency Strategy Unification](https://www.notion.so/35627bbd72b281068f8dd8025da4d3c8) plan (Step 3b).

## Test plan

- [ ] Renovate creates/updates a Dependency Dashboard issue on next run
- [ ] PR format matches expected config (labels, grouping, weekly schedule)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds Renovate configuration; no application, auth, or runtime code changes.
> 
> **Overview**
> Adds **`.github/renovate.json`** so this repo uses the org-wide Renovate preset pinned to **`trufflesecurity/.github:renovate-config#v1.0.1`** (high-risk tier).
> 
> Dependency update PRs will follow that preset: **no broad automerge** for normal bumps (Go, Node, Docker, Python, Actions); **security/CVE** and **lockfile maintenance** may automerge per preset once GitHub ruleset bypass is enabled later. Updates are scheduled for **Monday mornings (UTC)** with a **3-day minimum release age**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5b18a16be890b01c4a16b3ac33d9b7b0653084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->